### PR TITLE
fix chinese logout incorrect translation on mobile

### DIFF
--- a/translations/mobile/chinese.json
+++ b/translations/mobile/chinese.json
@@ -1,1 +1,3 @@
-{}
+{
+    "SETTINGS_RESET_ACCOUNT": "登出"
+}


### PR DESCRIPTION
The text now corresponding to logout is "reset wallet", confusing users.